### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v1
         with:
           submodules: recursive
-      - uses: elgohr/Publish-Docker-Github-Action@master
+      - uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           GIT_REV: $GITHUB_SHA
         with:
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v1
         with:
           submodules: recursive
-      - uses: elgohr/Publish-Docker-Github-Action@master
+      - uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           GIT_REV: $GITHUB_SHA
         with:

--- a/.github/workflows/build_gateway.yml
+++ b/.github/workflows/build_gateway.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v1
         with:
           submodules: recursive
-      - uses: elgohr/Publish-Docker-Github-Action@master
+      - uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           GIT_REV: $GITHUB_SHA
         with:


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore